### PR TITLE
Remove unnecessary dependency from rob-cos-data-sharing plug

### DIFF
--- a/cos_registration_agent/ssh_key_manager.py
+++ b/cos_registration_agent/ssh_key_manager.py
@@ -1,6 +1,7 @@
 """Class to manage device SSH keys."""
 
 import logging
+import os
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -51,6 +52,7 @@ class SSHKeysManager:
             folder (str): Folder to save the keys.
         """
         try:
+            os.makedirs(folder, exist_ok=True)
             write_data(private_ssh_key, "device_rsa_key", folder)
             write_data(public_ssh_key, "device_rsa_key.pub", folder)
         except Exception as e:

--- a/snap/hooks/connect-plug-configuration-read
+++ b/snap/hooks/connect-plug-configuration-read
@@ -1,6 +1,3 @@
 #!/bin/sh -e
 
-if snapctl is-connected rob-cos-common-write ; then
-    $SNAP/usr/bin/register-device.sh
-fi
-
+$SNAP/usr/bin/register-device.sh

--- a/snap/hooks/connect-plug-rob-cos-common-write
+++ b/snap/hooks/connect-plug-rob-cos-common-write
@@ -1,5 +1,0 @@
-#!/bin/sh -e
-
-if snapctl is-connected configuration-read ; then
-    $SNAP/usr/bin/register-device.sh
-fi


### PR DESCRIPTION
This PR removes the dependency of registering a device from the data-sharing snap.
Since we are only using the data sharing snap for the ssh keys, the device registration can rely just on the configuration-read plug connected.
The registration script (setup-action) called when the configuration-read is plugged, generates the keys and writes them to $SNAP_COMMON/ of this same snap. So it does not really matter whether the connection to the rob-cos-data-sharing snap happens before or after the configuration-snap connection.
There are two use cases:
- If the auto connection to rob-cos-common-write happens before the registration script is executed (when configuration-read is plugged) then the empty `$SNAP_COMMON/rob-cos-shared-data` folder is just shared among the snaps and filled with the keys at registration.
- If the auto connection to rob-cos-common-write happens after the configuration has been plugged and the device registered, the keys already generated will be simply shared with the data sharing.

Tested on a robcos deployment.