### PR TITLE
Improve registration agent script flexibility

### DIFF
--- a/snap/local/register-device.sh
+++ b/snap/local/register-device.sh
@@ -1,25 +1,29 @@
 #!/bin/sh -e
 
-CONFIGURATION_FILE_PATH=$SNAP_COMMON/configuration/device.yaml
+CONFIGURATION_FILE_PATH=${SNAP_COMMON}/configuration/device.yaml
 
-if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
-    echo "Configuration file '$CONFIGURATION_FILE_PATH' does not exist."
+if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
+    echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
     exit 1
 fi
 
-REGISTRATION_CMD="$SNAP/bin/cos-registration-agent --shared-data-path $SNAP_COMMON/rob-cos-shared-data"
+# Set the registration command args based on configuration
+REGISTRATION_CMD_ARGS=""
 
 # Check if grafan_dashboards directory exists in configuration
-if [ -d "$SNAP_COMMON/configuration/grafana_dashboards" ]; then
-    REGISTRATION_CMD="$REGISTRATION_CMD --grafana-dashboards $SNAP_COMMON/configuration/grafana_dashboards"
+if [ -d "${SNAP_COMMON}/configuration/grafana_dashboards" ]; then
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --grafana-dashboards ${SNAP_COMMON}/configuration/grafana_dashboards"
 fi
 
 # Check if foxglove_layouts directory exists in configuration
-if [ -d "$SNAP_COMMON/configuration/foxglove_layouts" ]; then
-    REGISTRATION_CMD="$REGISTRATION_CMD --foxglove-studio-dashboards $SNAP_COMMON/configuration/foxglove_layouts"
+if [ -d "${SNAP_COMMON}/configuration/foxglove_layouts" ]; then
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --foxglove-studio-dashboards ${SNAP_COMMON}/configuration/foxglove_layouts"
 fi
 
-REGISTRATION_CMD="$REGISTRATION_CMD setup -c $CONFIGURATION_FILE_PATH"
-eval "$REGISTRATION_CMD"
+# Build the registration command with the args
+REGISTRATION_CMD="${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data"
+REGISTRATION_CMD="${REGISTRATION_CMD} ${REGISTRATION_CMD_ARGS} setup -c ${CONFIGURATION_FILE_PATH}"
+
+eval "${REGISTRATION_CMD}"
 
 snapctl start --enable ${SNAP_NAME}.update-device-configuration 2>&1

--- a/snap/local/register-device.sh
+++ b/snap/local/register-device.sh
@@ -20,10 +20,7 @@ if [ -d "${SNAP_COMMON}/configuration/foxglove_layouts" ]; then
     REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --foxglove-studio-dashboards ${SNAP_COMMON}/configuration/foxglove_layouts"
 fi
 
-# Build the registration command with the args
-REGISTRATION_CMD="${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data"
-REGISTRATION_CMD="${REGISTRATION_CMD} ${REGISTRATION_CMD_ARGS} setup -c ${CONFIGURATION_FILE_PATH}"
-
-eval "${REGISTRATION_CMD}"
+# Call the registration command with the args
+${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} setup -c ${CONFIGURATION_FILE_PATH}
 
 snapctl start --enable ${SNAP_NAME}.update-device-configuration 2>&1

--- a/snap/local/register-device.sh
+++ b/snap/local/register-device.sh
@@ -7,6 +7,19 @@ if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
     exit 1
 fi
 
-$SNAP/bin/cos-registration-agent --shared-data-path $SNAP_COMMON/rob-cos-shared-data --grafana-dashboards $SNAP_COMMON/configuration/grafana_dashboards --foxglove-studio-dashboards $SNAP_COMMON/configuration/foxglove_layouts setup -c $CONFIGURATION_FILE_PATH
+REGISTRATION_CMD="$SNAP/bin/cos-registration-agent --shared-data-path $SNAP_COMMON/rob-cos-shared-data"
+
+# Check if grafan_dashboards directory exists in configuration
+if [ -d "$SNAP_COMMON/configuration/grafana_dashboards" ]; then
+    REGISTRATION_CMD="$REGISTRATION_CMD --grafana-dashboards $SNAP_COMMON/configuration/grafana_dashboards"
+fi
+
+# Check if foxglove_layouts directory exists in configuration
+if [ -d "$SNAP_COMMON/configuration/foxglove_layouts" ]; then
+    REGISTRATION_CMD="$REGISTRATION_CMD --foxglove-studio-dashboards $SNAP_COMMON/configuration/foxglove_layouts"
+fi
+
+REGISTRATION_CMD="$REGISTRATION_CMD setup -c $CONFIGURATION_FILE_PATH"
+eval "$REGISTRATION_CMD"
 
 snapctl start --enable ${SNAP_NAME}.update-device-configuration 2>&1


### PR DESCRIPTION
Currently the register-device script assumes that the configuration snap will always contain a `grafana_dahsboard` and `foxglove layouts` folder. This is not necessarily true, as one might not want to use foxglove for instance. 
This PR makes it so that it is possible to setup a device with the agent even if the `foxglove_layouts` and/or `grafana_dashboards` folders are not present in the configuration snap.

Solves issue: https://github.com/canonical/cos-registration-agent/issues/40