### PR TITLE
Fix missing argument in get ip address function on update

### DIFF
--- a/cos_registration_agent/cli.py
+++ b/cos_registration_agent/cli.py
@@ -198,7 +198,7 @@ def main():
 
         elif args.action == "update":
             data_to_update = {}
-            data_to_update["address"] = get_machine_ip_address()
+            data_to_update["address"] = get_machine_ip_address(args.url)
             if args.update_ssh_keys:
                 public_ssh_key = ssh_key_manager.setup(
                     folder=args.shared_data_path


### PR DESCRIPTION
Bug fix: pass url argument to the function retrieving the IP address of a registered device.
Without this argument, the cos-registration-agent `update` action fails to update the IP address.