### PR TITLE
Add ability to resolve registration server with domain name, add test

### DIFF
--- a/cos_registration_agent/machine_ip_address.py
+++ b/cos_registration_agent/machine_ip_address.py
@@ -7,6 +7,7 @@ from pyroute2 import IPRoute
 
 logger = logging.getLogger(__name__)
 
+
 def get_machine_ip_address(url: str) -> str:
     """Get the machine ip address."""
     try:

--- a/cos_registration_agent/machine_ip_address.py
+++ b/cos_registration_agent/machine_ip_address.py
@@ -14,6 +14,9 @@ def get_machine_ip_address(url: str) -> str:
         parsed_url = urllib.parse.urlparse(url)
         host = parsed_url.hostname
 
+        if host is None:
+            raise ValueError(f"Invalid URL, no hostname found: {url}")
+
         # Resolve hostname to IP address if needed
         try:
             host = socket.gethostbyname(host)
@@ -33,6 +36,8 @@ def get_machine_ip_address(url: str) -> str:
         for attr in route_info[0]["attrs"]:
             if attr[0] == "RTA_PREFSRC":
                 ip_address = attr[1]
+                break
+
         return ip_address
     except ConnectionError as e:
         logger.error("Failed to get machine id address:", e)

--- a/cos_registration_agent/machine_ip_address.py
+++ b/cos_registration_agent/machine_ip_address.py
@@ -2,17 +2,23 @@
 
 import logging
 import urllib.parse
-
+import socket
 from pyroute2 import IPRoute
 
 logger = logging.getLogger(__name__)
-
 
 def get_machine_ip_address(url: str) -> str:
     """Get the machine ip address."""
     try:
         parsed_url = urllib.parse.urlparse(url)
         host = parsed_url.hostname
+
+        # Resolve hostname to IP address if needed
+        try:
+            host = socket.gethostbyname(host)
+        except socket.gaierror as e:
+            logger.error(f"Failed to resolve hostname {host}: {e}")
+            raise
 
         with IPRoute() as ipr:
             route_info = ipr.route("get", dst=host)

--- a/cos_registration_agent/machine_ip_address.py
+++ b/cos_registration_agent/machine_ip_address.py
@@ -9,7 +9,20 @@ logger = logging.getLogger(__name__)
 
 
 def get_machine_ip_address(url: str) -> str:
-    """Get the machine ip address."""
+    """Get the machine ip address.
+
+    Args:
+        url (str): The URL to resolve.
+
+    Returns:
+        str: The machine's source IP address used to reach the provided url.
+
+    Raises:
+        ValueError: when the URL does not have a hostname.
+        ConnectionError: If the hostname cannot be resolved
+          or the route can't be determined.
+    """
+
     try:
         parsed_url = urllib.parse.urlparse(url)
         host = parsed_url.hostname
@@ -22,7 +35,7 @@ def get_machine_ip_address(url: str) -> str:
             host = socket.gethostbyname(host)
         except socket.gaierror as e:
             logger.error(f"Failed to resolve hostname {host}: {e}")
-            raise
+            raise ConnectionError(f"Failed to resolve hostname {host}") from e
 
         with IPRoute() as ipr:
             route_info = ipr.route("get", dst=host)

--- a/cos_registration_agent/machine_ip_address.py
+++ b/cos_registration_agent/machine_ip_address.py
@@ -22,7 +22,6 @@ def get_machine_ip_address(url: str) -> str:
         ConnectionError: If the hostname cannot be resolved
           or the route can't be determined.
     """
-
     try:
         parsed_url = urllib.parse.urlparse(url)
         host = parsed_url.hostname

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ grafana_client
 cryptography
 requests
 pyroute2
+socket

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ grafana_client
 cryptography
 requests
 pyroute2
-socket

--- a/tests/test_machine_ip_address.py
+++ b/tests/test_machine_ip_address.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from cos_registration_agent.machine_ip_address import get_machine_ip_address
+
+class TestGetMachineIPAddress(unittest.TestCase):
+    @patch("cos_registration_agent.machine_ip_address.socket.gethostbyname")
+    @patch("cos_registration_agent.machine_ip_address.IPRoute")
+    def test_get_machine_ip_address(self, mock_iproute, mock_gethostbyname):
+        test_url = "http://test.com"
+        mock_gethostbyname.return_value = "1.2.3.4"
+
+        # Mock IPRoute behavior to return mock IP
+        mock_ipr_instance = MagicMock()
+        mock_iproute.return_value.__enter__.return_value = mock_ipr_instance
+        mock_ipr_instance.route.return_value = [
+            {"attrs": [("RTA_PREFSRC", "1.1.1.1")]}
+        ]
+
+        result = get_machine_ip_address(test_url)
+        self.assertEqual(result, "1.1.1.1")
+
+        mock_gethostbyname.assert_called_once_with("test.com")
+        mock_ipr_instance.route.assert_called_once_with("get", dst="1.2.3.4")
+
+    @patch("cos_registration_agent.machine_ip_address.socket.gethostbyname")
+    @patch("cos_registration_agent.machine_ip_address.IPRoute")
+    def test_get_machine_ip_address_with_ip_url(self, mock_iproute, mock_gethostbyname):
+        test_url = "http://1.2.3.4/test"
+        mock_gethostbyname.return_value = "1.2.3.4"
+
+        # Mock IPRoute behavior to return mock IP
+        mock_ipr_instance = MagicMock()
+        mock_iproute.return_value.__enter__.return_value = mock_ipr_instance
+        mock_ipr_instance.route.return_value = [
+            {"attrs": [("RTA_PREFSRC", "1.1.1.1")]}
+        ]
+
+        result = get_machine_ip_address(test_url)
+        self.assertEqual(result, "1.1.1.1")
+
+        mock_gethostbyname.assert_called_once_with("1.2.3.4")
+        mock_ipr_instance.route.assert_called_once_with("get", dst="1.2.3.4")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_machine_ip_address.py
+++ b/tests/test_machine_ip_address.py
@@ -2,10 +2,13 @@ import unittest
 from unittest.mock import patch, MagicMock
 from cos_registration_agent.machine_ip_address import get_machine_ip_address
 
+
 class TestGetMachineIPAddress(unittest.TestCase):
     @patch("cos_registration_agent.machine_ip_address.socket.gethostbyname")
     @patch("cos_registration_agent.machine_ip_address.IPRoute")
-    def test_get_machine_ip_address(self, mock_iproute, mock_gethostbyname):
+    def test_get_machine_ip_address_dns(
+        self, mock_iproute, mock_gethostbyname
+    ):
         test_url = "http://test.com"
         mock_gethostbyname.return_value = "1.2.3.4"
 
@@ -24,7 +27,9 @@ class TestGetMachineIPAddress(unittest.TestCase):
 
     @patch("cos_registration_agent.machine_ip_address.socket.gethostbyname")
     @patch("cos_registration_agent.machine_ip_address.IPRoute")
-    def test_get_machine_ip_address_with_ip_url(self, mock_iproute, mock_gethostbyname):
+    def test_get_machine_ip_address_with_ip(
+        self, mock_iproute, mock_gethostbyname
+    ):
         test_url = "http://1.2.3.4/test"
         mock_gethostbyname.return_value = "1.2.3.4"
 
@@ -40,6 +45,7 @@ class TestGetMachineIPAddress(unittest.TestCase):
 
         mock_gethostbyname.assert_called_once_with("1.2.3.4")
         mock_ipr_instance.route.assert_called_once_with("get", dst="1.2.3.4")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR allows to correctly retrieve device IP for devices registering to a cos server url served behind a DNS (e.g. stg-server.com/cos-registration-server).  
It does so by adding a step to the `machine_ip_address` function to resolve url hostname to corresponding IP address with `socket.gethostbyname()`. This is required by iproute, which needs a valid IP. Without a valid IP it triggers the following error:
Error:
```
self['value'] = inet_pton(family, self.value)
OSError: illegal IP address string passed to inet_pton
```
The PR also adds 2 unit tests to verify the correct behaviour.