### PR TITLE
Feat/add fallback configuration mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ and finally install it with:
 sudo snap install cos-registration-agent*.snap --dangerous
 ```
 
-### Store
+### Snap Store
 
-The snap can also be installed directly from the store with:
+The snap can also be installed directly from the Snap Store with:
 
 ```
 sudo snap install cos-registration-agent --edge
 ```
 
-The snap is available on the Store for both amd64 and arm64.
+The snap is available on the Snap Store for both amd64 and arm64.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,30 @@ where it is made available for other snaps on the device.
 Delete is responsible for deleting the device from COS registration server.
 
 ## Installation
-The COS registration agent required systemd.
+The COS registration agent requires systemd.
 
-To install the `cos-registration-agent``, you must build and install the snap:
+### Local
+
+To install the `cos-registration-agent`, you can build it first with:
 ```
 snapcraft
 ```
+
+and finally install it with:
+
 ```
 sudo snap install cos-registration-agent*.snap --dangerous
 ```
+
+### Store
+
+The snap can also be installed directly from the store with:
+
+```
+sudo snap install cos-registration-agent --edge
+```
+
+The snap is available on the Store for both amd64 and arm64.
 
 ## Usage
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,26 @@
+#!/bin/sh -e
+
+CONFIG_PATH="$(snapctl get configuration-path)"
+
+if [ -n "${CONFIG_PATH}" ]; then
+    if snapctl is-connected configuration-read; then
+      logger -t ${SNAP_NAME} "Plug 'configuration-read' is connected"
+      exit 0
+    fi
+
+    case "${CONFIG_PATH}" in
+        ./*) ;;
+        *) 
+            echo "Invalid path. The path must be relative to root (starting with './')."
+            exit 1
+            ;;
+    esac
+
+    CONFIG_PATH="/root/$(realpath --relative-to=/ "${CONFIG_PATH}")"
+
+    if [ ! -d "${CONFIG_PATH}" ]; then
+        echo "Error: configuration-path '${CONFIG_PATH}' does not exist."
+        exit 1
+    fi
+    $SNAP/usr/bin/register-device.sh "${CONFIG_PATH}/device.yaml"
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -2,24 +2,26 @@
 
 CONFIG_PATH="$(snapctl get configuration-path)"
 
+# use fallback configuration mechanism if the configuration-path is set
 if [ -n "${CONFIG_PATH}" ]; then
+    # but always give precedence to the configuration-read plug
     if snapctl is-connected configuration-read; then
       logger -t ${SNAP_NAME} "Plug 'configuration-read' is connected"
       exit 0
     fi
 
     case "${CONFIG_PATH}" in
-        ./*) ;;
-        *) 
-            echo "Invalid path. The path must be relative to root (starting with './')."
+        /root*) ;;
+        *)
+            >&2 echo "Invalid path. The path must be relative to root (starting with '/root')."
+            logger -t ${SNAP_NAME} "Invalid path. The path must be relative to root (starting with '/root')."
             exit 1
             ;;
     esac
 
-    CONFIG_PATH="/root/$(realpath --relative-to=/ "${CONFIG_PATH}")"
-
     if [ ! -d "${CONFIG_PATH}" ]; then
-        echo "Error: configuration-path '${CONFIG_PATH}' does not exist."
+        >&2 echo "Error: configuration-path '${CONFIG_PATH}' does not exist."
+        logger -t ${SNAP_NAME} "Error: configuration-path '${CONFIG_PATH}' does not exist."
         exit 1
     fi
     $SNAP/usr/bin/register-device.sh "${CONFIG_PATH}/device.yaml"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -2,27 +2,21 @@
 
 CONFIG_PATH="$(snapctl get configuration-path)"
 
-# use fallback configuration mechanism if the configuration-path is set
+# Use fallback configuration mechanism if the configuration-path is set
 if [ -n "${CONFIG_PATH}" ]; then
-    # but always give precedence to the configuration-read plug
+    # But always give precedence to the configuration-read plug
     if snapctl is-connected configuration-read; then
-      logger -t ${SNAP_NAME} "Plug 'configuration-read' is connected"
-      exit 0
+      logger -t ${SNAP_NAME} "Plug 'configuration-read' is connected, \
+        the configuration-path parameter will be ignored"
+      exit 1
     fi
 
-    case "${CONFIG_PATH}" in
-        /root*) ;;
-        *)
-            >&2 echo "Invalid path. The path must be relative to root (starting with '/root')."
-            logger -t ${SNAP_NAME} "Invalid path. The path must be relative to root (starting with '/root')."
-            exit 1
-            ;;
-    esac
-
-    if [ ! -d "${CONFIG_PATH}" ]; then
-        >&2 echo "Error: configuration-path '${CONFIG_PATH}' does not exist."
-        logger -t ${SNAP_NAME} "Error: configuration-path '${CONFIG_PATH}' does not exist."
+    if [ ! -d "/root/${CONFIG_PATH}" ]; then
+        >&2 echo "Error: configuration-path '${CONFIG_PATH}' does not exist. \
+            The path must be relative to root (starting with '/root')"
+        logger -t ${SNAP_NAME} "Error: configuration-path '${CONFIG_PATH}' does not exist. \
+            The path must be relative to root (starting with '/root')"
         exit 1
     fi
-    $SNAP/usr/bin/register-device.sh "${CONFIG_PATH}/device.yaml"
+    $SNAP/usr/bin/register-device.sh "/root/${CONFIG_PATH}/device.yaml"
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+snapctl set configuration-path!

--- a/snap/local/register-device.sh
+++ b/snap/local/register-device.sh
@@ -2,10 +2,16 @@
 
 CONFIGURATION_FILE_PATH=${SNAP_COMMON}/configuration/device.yaml
 
+if [ -n "$1" ]; then
+    CONFIGURATION_FILE_PATH="$1"
+fi
+
 if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
     echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
     exit 1
 fi
+
+echo "Using configuration file: $CONFIGURATION_FILE_PATH"
 
 # Set the registration command args based on configuration
 REGISTRATION_CMD_ARGS=""
@@ -34,4 +40,3 @@ fi
 ${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} setup -c ${CONFIGURATION_FILE_PATH}
 
 snapctl start --enable ${SNAP_NAME}.update-device-configuration 2>&1
-

--- a/snap/local/register-device.sh
+++ b/snap/local/register-device.sh
@@ -7,11 +7,11 @@ if [ -n "$1" ]; then
 fi
 
 if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
-    echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
+    >&2 echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
     exit 1
 fi
 
-echo "Using configuration file: $CONFIGURATION_FILE_PATH"
+>&2 echo "Using configuration file: $CONFIGURATION_FILE_PATH"
 
 # Set the registration command args based on configuration
 REGISTRATION_CMD_ARGS=""
@@ -37,6 +37,7 @@ if [ -d "${SNAP_COMMON}/configuration/prometheus_alert_rules" ]; then
 fi
 
 # Call the registration command with the args
-${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} setup -c ${CONFIGURATION_FILE_PATH}
+>&2 echo "register device with $CONFIGURATION_FILE_PATH"
+#${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} setup -c ${CONFIGURATION_FILE_PATH}
 
 snapctl start --enable ${SNAP_NAME}.update-device-configuration 2>&1

--- a/snap/local/register-device.sh
+++ b/snap/local/register-device.sh
@@ -7,11 +7,11 @@ if [ -n "$1" ]; then
 fi
 
 if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
-    echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
+    logger -t ${SNAP_NAME} "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
     exit 1
 fi
 
-echo "Using configuration file: ${CONFIGURATION_FILE_PATH}."
+logger -t ${SNAP_NAME} "Using configuration file: ${CONFIGURATION_FILE_PATH}."
 
 # Set the registration command args based on configuration
 REGISTRATION_CMD_ARGS=""

--- a/snap/local/register-device.sh
+++ b/snap/local/register-device.sh
@@ -7,11 +7,11 @@ if [ -n "$1" ]; then
 fi
 
 if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
-    >&2 echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
+    echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
     exit 1
 fi
 
->&2 echo "Using configuration file: $CONFIGURATION_FILE_PATH"
+echo "Using configuration file: $CONFIGURATION_FILE_PATH"
 
 # Set the registration command args based on configuration
 REGISTRATION_CMD_ARGS=""
@@ -37,7 +37,6 @@ if [ -d "${SNAP_COMMON}/configuration/prometheus_alert_rules" ]; then
 fi
 
 # Call the registration command with the args
->&2 echo "register device with $CONFIGURATION_FILE_PATH"
-#${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} setup -c ${CONFIGURATION_FILE_PATH}
+${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} setup -c ${CONFIGURATION_FILE_PATH}
 
 snapctl start --enable ${SNAP_NAME}.update-device-configuration 2>&1

--- a/snap/local/register-device.sh
+++ b/snap/local/register-device.sh
@@ -11,7 +11,7 @@ if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
     exit 1
 fi
 
-echo "Using configuration file: $CONFIGURATION_FILE_PATH"
+echo "Using configuration file: ${CONFIGURATION_FILE_PATH}."
 
 # Set the registration command args based on configuration
 REGISTRATION_CMD_ARGS=""

--- a/snap/local/update-device-configuration.sh
+++ b/snap/local/update-device-configuration.sh
@@ -4,9 +4,9 @@ CONFIGURATION_FILE_PATH="$SNAP_COMMON/configuration/device.yaml"
 
 CONFIG_PATH_PARAMETER="$(snapctl get configuration-path)"
 
-# use fallback configuration mechanism if the configuration-path is set
+# Use fallback configuration mechanism if the configuration-path is set
 if [ -n "${CONFIG_PATH_PARAMETER}" ]; then
-    CONFIGURATION_FILE_PATH=${CONFIG_PATH_PARAMETER}/device.yaml
+    CONFIGURATION_FILE_PATH="/root/${CONFIG_PATH_PARAMETER}/device.yaml"
 fi
 
 if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
@@ -14,7 +14,7 @@ if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
     exit 1
 fi
 
-echo "Using configuration file: $CONFIGURATION_FILE_PATH"
+echo "Using configuration file: ${CONFIGURATION_FILE_PATH}."
 
 # Set the registration command args based on configuration
 REGISTRATION_CMD_ARGS=""

--- a/snap/local/update-device-configuration.sh
+++ b/snap/local/update-device-configuration.sh
@@ -11,10 +11,12 @@ fi
 
 if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
     echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
+    logger -t ${SNAP_NAME} "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
     exit 1
 fi
 
 echo "Using configuration file: ${CONFIGURATION_FILE_PATH}."
+logger -t ${SNAP_NAME} "Using configuration file: ${CONFIGURATION_FILE_PATH}."
 
 # Set the registration command args based on configuration
 REGISTRATION_CMD_ARGS=""

--- a/snap/local/update-device-configuration.sh
+++ b/snap/local/update-device-configuration.sh
@@ -10,7 +10,7 @@ if [ -n "${CONFIG_PATH_PARAMETER}" ]; then
 fi
 
 if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
-    >&2 echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
+    echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
     exit 1
 fi
 
@@ -40,6 +40,4 @@ if [ -d "${SNAP_COMMON}/configuration/prometheus_alert_rules" ]; then
 fi
 
 # Call the update command with the args
->&2 echo "update device with $CONFIGURATION_FILE_PATH"
-logger -t ${SNAP_NAME} "update device with $CONFIGURATION_FILE_PATH"
-#${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} update -c ${CONFIGURATION_FILE_PATH}
+${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} update -c ${CONFIGURATION_FILE_PATH}

--- a/snap/local/update-device-configuration.sh
+++ b/snap/local/update-device-configuration.sh
@@ -2,6 +2,20 @@
 
 CONFIGURATION_FILE_PATH="$SNAP_COMMON/configuration/device.yaml"
 
+CONFIG_PATH_PARAMETER="$(snapctl get configuration-path)"
+
+# use fallback configuration mechanism if the configuration-path is set
+if [ -n "${CONFIG_PATH_PARAMETER}" ]; then
+    CONFIGURATION_FILE_PATH=${CONFIG_PATH_PARAMETER}/device.yaml
+fi
+
+if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
+    >&2 echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
+    exit 1
+fi
+
+>&2 echo "Using configuration file: $CONFIGURATION_FILE_PATH"
+
 # Set the registration command args based on configuration
 REGISTRATION_CMD_ARGS=""
 
@@ -26,4 +40,6 @@ if [ -d "${SNAP_COMMON}/configuration/prometheus_alert_rules" ]; then
 fi
 
 # Call the update command with the args
-${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} update -c ${CONFIGURATION_FILE_PATH}
+>&2 echo "update device with $CONFIGURATION_FILE_PATH"
+logger -t ${SNAP_NAME} "update device with $CONFIGURATION_FILE_PATH"
+#${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} update -c ${CONFIGURATION_FILE_PATH}

--- a/snap/local/update-device-configuration.sh
+++ b/snap/local/update-device-configuration.sh
@@ -14,7 +14,7 @@ if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
     exit 1
 fi
 
->&2 echo "Using configuration file: $CONFIGURATION_FILE_PATH"
+echo "Using configuration file: $CONFIGURATION_FILE_PATH"
 
 # Set the registration command args based on configuration
 REGISTRATION_CMD_ARGS=""

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,6 +26,8 @@ plugs:
     target: $SNAP_COMMON/configuration
 
 hooks:
+  configure:
+    plugs: [network, home]
   connect-plug-configuration-read:
     plugs: [network]
   connect-plug-rob-cos-common-write:
@@ -48,7 +50,7 @@ apps:
     command: usr/bin/update-device-configuration.sh
     daemon: oneshot
     install-mode: disable
-    plugs: [network, rob-cos-common-write, configuration-read]
+    plugs: [network, rob-cos-common-write, configuration-read, home]
   cos-registration-agent:
     command: bin/cos-registration-agent
-    plugs: [network, rob-cos-common-write, configuration-read]
+    plugs: [network, rob-cos-common-write, configuration-read, home]


### PR DESCRIPTION
Add fallback mechanism to pass the configuration to the cos-registration-agent.
This snaps rely on the connection to a configuration snap (with a configuration-read plug), to get its configuration. This allows to use the cos-registration-agent without a configuration snap, by setting a `configuration-path` parameter. 

The registration with fallback is triggered by running for instance:

`snap set cos-registration-agent configuration-path="/root/configuration"`

The parameter must be a path in `/root`, because, in order to preserve automatic registration, the registration happens in the `configure` hook (whose home is `/root`). 
Precedence is always given to the configuration-read hook.


Add also small fixes to README.