### PR TITLE
Use correct arguments when registering/updating device with rules

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -13,9 +13,9 @@ if [ -n "${CONFIG_PATH}" ]; then
 
     if [ ! -d "/root/${CONFIG_PATH}" ]; then
         >&2 echo "Error: configuration-path '${CONFIG_PATH}' does not exist. \
-            The path must be relative to root (starting with '/root')"
+            The path must be relative to /root."
         logger -t ${SNAP_NAME} "Error: configuration-path '${CONFIG_PATH}' does not exist. \
-            The path must be relative to root (starting with '/root')"
+            The path must be relative to /root."
         exit 1
     fi
     $SNAP/usr/bin/register-device.sh "/root/${CONFIG_PATH}/device.yaml"

--- a/snap/local/register-device.sh
+++ b/snap/local/register-device.sh
@@ -28,12 +28,12 @@ fi
 
 # Check if loki_alert_rules directory exists in configuration
 if [ -d "${SNAP_COMMON}/configuration/loki_alert_rules" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --loki-rules-files ${SNAP_COMMON}/configuration/loki_alert_rules"
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --loki-alert-rule-files ${SNAP_COMMON}/configuration/loki_alert_rules"
 fi
 
 # Check if prometheus_alert_rules directory exists in configuration
 if [ -d "${SNAP_COMMON}/configuration/prometheus_alert_rules" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --prometheus-rules-files ${SNAP_COMMON}/configuration/prometheus_alert_rules"
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --prometheus-alert-rule-files ${SNAP_COMMON}/configuration/prometheus_alert_rules"
 fi
 
 # Call the registration command with the args

--- a/snap/local/update-device-configuration.sh
+++ b/snap/local/update-device-configuration.sh
@@ -33,12 +33,12 @@ fi
 
 # Check if loki_alert_rules directory exists in configuration
 if [ -d "${SNAP_COMMON}/configuration/loki_alert_rules" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --loki-rules-files ${SNAP_COMMON}/configuration/loki_alert_rules"
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --loki-alert-rule-files ${SNAP_COMMON}/configuration/loki_alert_rules"
 fi
 
 # Check if prometheus_alert_rules directory exists in configuration
 if [ -d "${SNAP_COMMON}/configuration/prometheus_alert_rules" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --prometheus-rules-files ${SNAP_COMMON}/configuration/prometheus_alert_rules"
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --prometheus-alert-rule-files ${SNAP_COMMON}/configuration/prometheus_alert_rules"
 fi
 
 # Call the update command with the args


### PR DESCRIPTION
Use correct argoments to pass to the cli tool to register/update device with alert rules defined in configuration.