### PR TITLE
Fix path setting up device dashboards dashboards

### DIFF
--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
     # Use fallback configuration mechanism if the configuration-path is set
     if [ -n "${CONFIG_PATH}" ]; then
         echo "Configuration-path parameter has been set"
-        CONFIGURATION_FILE_PATH=/root/${CONFIG_PATH}/device.yaml
+        CONFIGURATION_FILE_PATH="/root/${CONFIG_PATH}/device.yaml"
     else
         echo "No valid configuration file has been found"
         exit 1
@@ -16,5 +16,5 @@ if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
 fi
 
 URL=$(grep '^url:' "$CONFIGURATION_FILE_PATH" | cut -d ' ' -f 2)
-UID=$(grep '^uid:' "$CONFIGURATION_FILE_PATH" | cut -d ' ' -f 2)
-$SNAP/bin/cos-registration-agent delete --url $URL --uid $UID
+UUID=$(grep '^uid:' "$CONFIGURATION_FILE_PATH" | cut -d ' ' -f 2)
+$SNAP/bin/cos-registration-agent delete --url $URL --uid $UUID

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
     # Use fallback configuration mechanism if the configuration-path is set
     if [ -n "${CONFIG_PATH}" ]; then
         echo "Configuration-path parameter has been set"
-        CONFIGURATION_FILE_PATH=${CONFIG_PATH}
+        CONFIGURATION_FILE_PATH=${CONFIG_PATH}/device.yaml
     else
         echo "No valid configuration file has been found"
         exit 1

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -7,8 +7,8 @@ if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
     echo "Configuration file '$CONFIGURATION_FILE_PATH' does not exist."
     # Use fallback configuration mechanism if the configuration-path is set
     if [ -n "${CONFIG_PATH}" ]; then
-        echo "Configuration-path parameter has been set"
         CONFIGURATION_FILE_PATH="/root/${CONFIG_PATH}/device.yaml"
+        echo "Configuration-path set, device config file path is: ${CONFIGURATION_FILE_PATH}"
     else
         echo "No valid configuration file has been found"
         exit 1

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -8,7 +8,7 @@ if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
     # Use fallback configuration mechanism if the configuration-path is set
     if [ -n "${CONFIG_PATH}" ]; then
         echo "Configuration-path parameter has been set"
-        CONFIGURATION_FILE_PATH=${CONFIG_PATH}/device.yaml
+        CONFIGURATION_FILE_PATH=/root/${CONFIG_PATH}/device.yaml
     else
         echo "No valid configuration file has been found"
         exit 1

--- a/snap/local/register-device.sh
+++ b/snap/local/register-device.sh
@@ -13,27 +13,30 @@ fi
 
 logger -t ${SNAP_NAME} "Using configuration file: ${CONFIGURATION_FILE_PATH}."
 
+# Retrieve the directory at which the configuration is stored
+CONFIGURATION_DIR_PATH="$(dirname "${CONFIGURATION_FILE_PATH}")"
+
 # Set the registration command args based on configuration
 REGISTRATION_CMD_ARGS=""
 
 # Check if grafan_dashboards directory exists in configuration
-if [ -d "${CONFIGURATION_FILE_PATH}/grafana_dashboards" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --grafana-dashboards ${CONFIGURATION_FILE_PATH}/grafana_dashboards"
+if [ -d "${CONFIGURATION_DIR_PATH}/grafana_dashboards" ]; then
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --grafana-dashboards ${CONFIGURATION_DIR_PATH}/grafana_dashboards"
 fi
 
 # Check if foxglove_layouts directory exists in configuration
-if [ -d "${CONFIGURATION_FILE_PATH}/foxglove_layouts" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --foxglove-studio-dashboards ${CONFIGURATION_FILE_PATH}/foxglove_layouts"
+if [ -d "${CONFIGURATION_DIR_PATH}/foxglove_layouts" ]; then
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --foxglove-studio-dashboards ${CONFIGURATION_DIR_PATH}/foxglove_layouts"
 fi
 
 # Check if loki_alert_rules directory exists in configuration
-if [ -d "${CONFIGURATION_FILE_PATH}/loki_alert_rules" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --loki-alert-rule-files ${CONFIGURATION_FILE_PATH}/loki_alert_rules"
+if [ -d "${CONFIGURATION_DIR_PATH}/loki_alert_rules" ]; then
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --loki-alert-rule-files ${CONFIGURATION_DIR_PATH}/loki_alert_rules"
 fi
 
 # Check if prometheus_alert_rules directory exists in configuration
-if [ -d "${CONFIGURATION_FILE_PATH}/prometheus_alert_rules" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --prometheus-alert-rule-files ${CONFIGURATION_FILE_PATH}/prometheus_alert_rules"
+if [ -d "${CONFIGURATION_DIR_PATH}/prometheus_alert_rules" ]; then
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --prometheus-alert-rule-files ${CONFIGURATION_DIR_PATH}/prometheus_alert_rules"
 fi
 
 # Call the registration command with the args

--- a/snap/local/update-device-configuration.sh
+++ b/snap/local/update-device-configuration.sh
@@ -18,28 +18,31 @@ fi
 echo "Using configuration file: ${CONFIGURATION_FILE_PATH}."
 logger -t ${SNAP_NAME} "Using configuration file: ${CONFIGURATION_FILE_PATH}."
 
+# Retrieve the directory at which the configuration is stored
+CONFIGURATION_DIR_PATH="$(dirname "${CONFIGURATION_FILE_PATH}")"
+
 # Set the registration command args based on configuration
 REGISTRATION_CMD_ARGS=""
 
 # Check if grafan_dashboards directory exists in configuration
-if [ -d "${CONFIGURATION_FILE_PATH}/grafana_dashboards" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --grafana-dashboards ${CONFIGURATION_FILE_PATH}/grafana_dashboards"
+if [ -d "${CONFIGURATION_DIR_PATH}/grafana_dashboards" ]; then
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --grafana-dashboards ${CONFIGURATION_DIR_PATH}/grafana_dashboards"
 fi
 
 # Check if foxglove_layouts directory exists in configuration
-if [ -d "${CONFIGURATION_FILE_PATH}/foxglove_layouts" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --foxglove-studio-dashboards ${CONFIGURATION_FILE_PATH}/foxglove_layouts"
+if [ -d "${CONFIGURATION_DIR_PATH}/foxglove_layouts" ]; then
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --foxglove-studio-dashboards ${CONFIGURATION_DIR_PATH}/foxglove_layouts"
 fi
 
 # Check if loki_alert_rules directory exists in configuration
-if [ -d "${CONFIGURATION_FILE_PATH}/loki_alert_rules" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --loki-alert-rule-files ${CONFIGURATION_FILE_PATH}/loki_alert_rules"
+if [ -d "${CONFIGURATION_DIR_PATH}/loki_alert_rules" ]; then
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --loki-alert-rule-files ${CONFIGURATION_DIR_PATH}/loki_alert_rules"
 fi
 
 # Check if prometheus_alert_rules directory exists in configuration
-if [ -d "${CONFIGURATION_FILE_PATH}/prometheus_alert_rules" ]; then
-    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --prometheus-alert-rule-files ${CONFIGURATION_FILE_PATH}/prometheus_alert_rules"
+if [ -d "${CONFIGURATION_DIR_PATH}/prometheus_alert_rules" ]; then
+    REGISTRATION_CMD_ARGS="${REGISTRATION_CMD_ARGS} --prometheus-alert-rule-files ${CONFIGURATION_DIR_PATH}/prometheus_alert_rules"
 fi
 
 # Call the update command with the args
-${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} update -c ${CONFIGURATION_FILE_PATH}
+${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} update -c ${CONFIGURATION_DIR_PATH}

--- a/snap/local/update-device-configuration.sh
+++ b/snap/local/update-device-configuration.sh
@@ -45,4 +45,4 @@ if [ -d "${CONFIGURATION_DIR_PATH}/prometheus_alert_rules" ]; then
 fi
 
 # Call the update command with the args
-${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} update -c ${CONFIGURATION_DIR_PATH}
+${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} update -c ${CONFIGURATION_FILE_PATH}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,7 @@ hooks:
   connect-plug-rob-cos-common-write:
     plugs: [network]
   remove:
-    plugs: [network, configuration-read]
+    plugs: [network, home, configuration-read]
 
 parts:
   local-files:


### PR DESCRIPTION
This PR fixes an issue with setting up the arguments when registering/updating the devices. It uses the configuration directory, either with fallback or with configuration snap depending on the parameter being set or not.
It also fixes the device remove hook with fallback.

Tested on a staging deployment with a device.