### PR TITLE
feat(snap): add a delete-device service

### DIFF
--- a/snap/hooks/connect-plug-configuration-read
+++ b/snap/hooks/connect-plug-configuration-read
@@ -2,5 +2,5 @@
 
 if ! $SNAP/usr/bin/register-device.sh; then
   logger -t "${SNAP_NAME}" "device registration failed in connect-plug-configuration-read"
-  logger -t "${SNAP_NAME}" "You can try again later by running: sudo snap run ${SNAP_NAME}.force-register-device"
+  logger -t "${SNAP_NAME}" "You can try again later by running: sudo snap run ${SNAP_NAME}.register-device"
 fi

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,33 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CONFIGURATION_FILE_PATH="${SNAP_COMMON}/configuration/device.yaml"
-IDENTITY_TOKEN_FILE_PATH="${SNAP_COMMON}/rob-cos-shared-data/identity/token.txt"
-CONFIG_PATH="$(snapctl get configuration-path)"
-
-if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
-    echo "Configuration file '$CONFIGURATION_FILE_PATH' does not exist."
-    # Use fallback configuration mechanism if the configuration-path is set
-    if [ -n "${CONFIG_PATH}" ]; then
-        CONFIGURATION_FILE_PATH="/root/${CONFIG_PATH}/device.yaml"
-        echo "Configuration-path set, device config file path is: ${CONFIGURATION_FILE_PATH}"
-    else
-        echo "No valid configuration file has been found"
-        exit 1
-    fi
+if ! $SNAP/usr/bin/delete-device.sh; then
+  logger -t "${SNAP_NAME}" "device deletion failed in remove hook"
 fi
 
-URL=$(grep '^url:' "$CONFIGURATION_FILE_PATH" | cut -d ' ' -f 2)
-UUID=$(grep '^uid:' "$CONFIGURATION_FILE_PATH" | cut -d ' ' -f 2)
-
-# Set the command args based on configuration
-CMD_ARGS=(--url "${URL}" --uid "${UUID}")
-
-GLOBAL_ARGS=()
-
-# Check if identity token exists in configuration
-if [ -f "${IDENTITY_TOKEN_FILE_PATH}" ]; then
-    GLOBAL_ARGS+=(--token-file "${IDENTITY_TOKEN_FILE_PATH}")
-fi
-
-"$SNAP/bin/cos-registration-agent" "${GLOBAL_ARGS[@]}" delete "${CMD_ARGS[@]}"

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-if ! $SNAP/usr/bin/delete-device.sh; then
+if ! "${SNAP}/usr/bin/delete-device.sh"; then
   logger -t "${SNAP_NAME}" "device deletion failed in remove hook"
+  exit 1
 fi
 

--- a/snap/local/delete-device.sh
+++ b/snap/local/delete-device.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+CONFIGURATION_FILE_PATH="${SNAP_COMMON}/configuration/device.yaml"
+IDENTITY_TOKEN_FILE_PATH="${SNAP_COMMON}/rob-cos-shared-data/identity/token.txt"
+CONFIG_PATH="$(snapctl get configuration-path)"
+
+if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
+    echo "Configuration file '$CONFIGURATION_FILE_PATH' does not exist."
+    # Use fallback configuration mechanism if the configuration-path is set
+    if [ -n "${CONFIG_PATH}" ]; then
+        CONFIGURATION_FILE_PATH="/root/${CONFIG_PATH}/device.yaml"
+        echo "Configuration-path set, device config file path is: ${CONFIGURATION_FILE_PATH}"
+    else
+        echo "No valid configuration file has been found"
+        exit 1
+    fi
+fi
+
+URL=$(grep '^url:' "$CONFIGURATION_FILE_PATH" | cut -d ' ' -f 2)
+UUID=$(grep '^uid:' "$CONFIGURATION_FILE_PATH" | cut -d ' ' -f 2)
+
+# Set the command args based on configuration
+CMD_ARGS=(--url "${URL}" --uid "${UUID}")
+
+GLOBAL_ARGS=()
+
+# Check if identity token exists in configuration
+if [ -f "${IDENTITY_TOKEN_FILE_PATH}" ]; then
+    GLOBAL_ARGS+=(--token-file "${IDENTITY_TOKEN_FILE_PATH}")
+fi
+
+"$SNAP/bin/cos-registration-agent" "${GLOBAL_ARGS[@]}" delete "${CMD_ARGS[@]}"
+

--- a/snap/local/delete-device.sh
+++ b/snap/local/delete-device.sh
@@ -32,3 +32,5 @@ fi
 
 "$SNAP/bin/cos-registration-agent" "${GLOBAL_ARGS[@]}" delete "${CMD_ARGS[@]}"
 
+logger -t ${SNAP_NAME} "Successfully deleted the device."
+

--- a/snap/local/register-device.sh
+++ b/snap/local/register-device.sh
@@ -48,4 +48,6 @@ fi
 # Call the registration command with the args
 ${SNAP}/bin/cos-registration-agent --shared-data-path ${SNAP_COMMON}/rob-cos-shared-data ${REGISTRATION_CMD_ARGS} setup -c ${CONFIGURATION_FILE_PATH}
 
+logger -t ${SNAP_NAME} "Successfully registered the device."
+
 snapctl start --enable ${SNAP_NAME}.update-device-configuration 2>&1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,6 +63,11 @@ apps:
     daemon: oneshot
     install-mode: disable
     plugs: [network, rob-cos-common-write, configuration-read, home]
+  delete-device:
+    command: usr/bin/delete-device.sh
+    daemon: oneshot
+    install-mode: disable
+    plugs: [network, rob-cos-common-write, configuration-read, home]
   cos-registration-agent:
     command: bin/cos-registration-agent
     plugs: [network, rob-cos-common-write, configuration-read, home]


### PR DESCRIPTION
Since we will want to delete a device in the rob-cos overlay integration tests.
Similarly to the `register-device` service I added a `delete-device`.